### PR TITLE
升级到Vue2版本

### DIFF
--- a/src/BootstrapTable.vue
+++ b/src/BootstrapTable.vue
@@ -1,81 +1,88 @@
 <template>
 <div class="bootstrap-table">
     <div class="fixed-table-toolbar">
-        <div class="bs-bars pull-{{options.toolbarAlign}}">
+        <div class="bs-bars" :class="'pull-'+local.options.toolbarAlign">
             <slot></slot>
         </div>
-        <div class="columns columns-{{options.buttonsAlign}} btn-group pull-{{options.buttonsAlign}}">
-            <button v-if="options.showPaginationSwitch"
-                class="btn btn-{{options.buttonsClass}} btn-{{options.iconSize}}"
+        <div class="columns btn-group"
+        :class="['columns-'+local.options.buttonsAlign, 'pull-'+local.options.buttonsAlign]">
+            <button v-if="local.options.showPaginationSwitch"
+                :class="['btn', 'btn-'+local.options.buttonsClass, 'btn-'+local.options.iconSize]"
                 type="button" name="paginationSwitch"
-                title="{{options.formatPaginationSwitch()}}"
-                v-on:click="togglePagination">
-                <i class="{{options.iconsPrefix}} {{paginationSwitchIcon}}"></i>
+                :title="local.options.formatPaginationSwitch()"
+                @click="togglePagination">
+                <i :class="[local.options.iconsPrefix, paginationSwitchIcon]"></i>
             </button>
-            <button v-if="options.showRefresh"
-                class="btn btn-{{options.buttonsClass}} btn-{{options.iconSize}}"
+            <button v-if="local.options.showRefresh"
+                :class="['btn', 'btn-'+local.options.buttonsClass, 'btn-'+local.options.iconSize]"
                 type="button" name="refresh"
-                title="{{options.formatRefresh()}}"
-                v-on:click="refresh">
-                <i class="{{options.iconsPrefix}} {{options.icons.refresh}}"></i>
+                :title="local.options.formatRefresh()"
+                @click="refresh">
+                <i :class="[local.options.iconsPrefix, local.options.icons.refresh]"></i>
             </button>
-            <button v-if="options.showToggle"
-                class="btn btn-{{options.buttonsClass}} btn-{{options.iconSize}}"
+            <button v-if="local.options.showToggle"
+                :class="['btn', 'btn-'+local.options.buttonsClass, 'btn-'+local.options.iconSize]"
                 type="button" name="toggle"
-                title="{{options.formatToggle()}}"
-                v-on:click="toggleView">
-                <i class="{{options.iconsPrefix}} {{options.icons.toggle}}"></i>
+                :title="local.options.formatToggle()"
+                @click="toggleView">
+                <i :class="[local.options.iconsPrefix, local.options.icons.toggle]"></i>
             </button>
-            <div v-if="options.showColumns" class="keep-open btn-group"
-                title="{{this.options.formatColumns()}}">
+            <div v-if="local.options.showColumns" class="keep-open btn-group"
+                :title="local.options.formatColumns()">
                 <button type="button" data-toggle="dropdown"
-                    class="btn btn-{{options.buttonsClass}} btn-{{options.iconSize}} dropdown-toggle">
-                    <i class="{{options.iconsPrefix}} {{options.icons.columns}}"></i> <span class="caret"></span>
+                    class="btn dropdown-toggle"
+                    :class="['btn-'+local.options.buttonsClass, 'btn-'+local.options.iconSize]">
+                    <i :class="[local.options.iconsPrefix, local.options.icons.columns]"></i>
+                    <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
-                    <li v-for="(i, column) in fieldColumns" v-on:click.stop>
-                        <label v-if="!(column.radio || column.checkbox || options.cardView && !column.cardVisible)">
-                            <input type="checkbox" data-field="{{column.filed}}"
-                                :disabled="toggleColumnsCount <= options.minimumCountColumns && column.visible"
+                    <li v-for="(column, i) in fieldColumns" @click.stop>
+                        <label v-if="!(column.radio || column.checkbox || local.options.cardView && !column.cardVisible)">
+                            <input type="checkbox" :data-field="column.filed"
+                                :disabled="toggleColumnsCount <= local.options.minimumCountColumns && column.visible"
                                 v-model="column.visible"> {{column.title}}
                         </label>
                     </li>
                 </ul>
             </div>
         </div>
-        <div v-if="options.search" class="pull-{{options.searchAlign}} search">
-            <input class="form-control input-{{options.iconSize}}"
-            type="text" placeholder="{{options.formatSearch()}}"
-            v-model="searchText" v-on:keyup="search($event)">
+        <div v-if="local.options.search" class="search"
+        :class="'pull-'+local.options.searchAlign">
+            <input class="form-control"
+            :class="'input-'+local.options.iconSize"
+            type="text" :placeholder="local.options.formatSearch()"
+            v-model="searchText" @keyup="search($event)">
         </div>
     </div>
     <div class="fixed-table-container"
-        v-bind:style="{'padding-bottom': (options.height ? view.headerHeight : 0) + 'px', height: options.height + 'px'}">
-        <div class="fixed-table-header" v-if="options.showHeader && !options.cardView && options.height">
-            <table class="{{options.classes}}">
+        :style="{'padding-bottom': (local.options.height ? view.headerHeight : 0) + 'px', height: local.options.height + 'px'}">
+        <div class="fixed-table-header" v-if="local.options.showHeader && !local.options.cardView && local.options.height">
+            <table :class="local.options.classes">
                 <thead>
-                    <tr v-for="_columns in columns">
-                        <th v-if="!options.cardView && options.detailView"
+                    <tr v-for="_columns in local.columns">
+                        <th v-if="!local.options.cardView && local.options.detailView"
                             class="detail" rowspan="columns.length">
                             <div class="fht-cell"></div>
                         </th>
                         <template v-for="column in _columns">
-                        <th v-if="!(!column.visible || options.cardView && !column.cardVisible)"
-                            title="{{{column.titleTooltip}}}"
-                            v-bind:class="[{'bs-checkbox': column.checkbox || column.radio}, column.class]"
-                            v-bind:style="column.style"
-                            rowspan="{{column.rowspan}}"
-                            colspan="{{column.colspan}}"
-                            data-field="{{column.field}}"
+                            <!-- hcc v-html:title="column.titleTooltip" -->
+                        <th v-if="column && !(!column.visible || local.options.cardView && !column.cardVisible)"
+                            v-html:title="column.titleTooltip"
+                            :class="[{'bs-checkbox': column.checkbox || column.radio}, column.class]"
+                            :style="column.style"
+                            :rowspan="column.rowspan"
+                            :colspan="column.colspan"
+                            :data-field="column.field"
                             tabindex="0">
                             <div class="th-inner"
-                                v-bind:class="[{sortable: options.sortable && column.sortable}, options.sortName == column.field ? options.sortOrder : 'both']"
-                                v-on:click="onSort(column)"
-                                v-on:keypress.enter="onSort(column)">
+                                :class="[{sortable: local.options.sortable && column.sortable},
+                                (local.options.sortable && column.sortable) ? (local.options.sortName == column.field ? local.options.sortOrder : 'both') : '']"
+                                @click="onSort(column)"
+                                @keypress.enter="onSort(column)">
 
-                                <input v-if="column.checkbox && !options.singleSelect && options.checkboxHeader"
+                                <input v-if="column.checkbox && !local.options.singleSelect && local.options.checkboxHeader"
                                     name="btSelectAll" type="checkbox" v-model="selected.all"
-                                    v-on:change="onCheckAllChange">
+                                    @change="onCheckAllChange">
 
                                 <template v-if="!column.checkbox && !column.radio">
                                 {{column.title}}
@@ -89,37 +96,38 @@
             </table>
         </div>
         <div class="fixed-table-body">
-            <div v-if="loading" class="fixed-table-loading"
-                v-bind:style="{top: view.headerHeight + 1 + 'px'}">
+            <div v-show="loading" class="fixed-table-loading"
+                :style="{top: view.headerHeight + 1 + 'px'}">
                 <div class="fixed-table-loading-bg"></div>
                 <div class="fixed-table-loading-text">
-                    {{options.formatLoadingMessage()}}
+                    {{local.options.formatLoadingMessage()}}
                 </div>
             </div>
-            <table class="{{options.classes}}">
-                <thead v-if="options.showHeader && !options.cardView && !options.height">
-                    <tr v-for="_columns in columns">
-                        <th v-if="!options.cardView && options.detailView"
+            <table :class="local.options.classes">
+                <thead v-if="local.options.showHeader && !local.options.cardView && !local.options.height">
+                    <tr v-for="_columns in local.columns">
+                        <th v-if="!local.options.cardView && local.options.detailView"
                             class="detail" rowspan="columns.length">
                             <div class="fht-cell"></div>
                         </th>
                         <template v-for="column in _columns">
-                        <th v-if="!(!column.visible || options.cardView && !column.cardVisible)"
-                            title="{{column.titleTooltip}}"
-                            v-bind:class="[{'bs-checkbox': column.checkbox || column.radio}, column.class]"
-                            v-bind:style="column.style"
-                            rowspan="{{column.rowspan}}"
-                            colspan="{{column.colspan}}"
-                            data-field="{{column.field}}"
+                        <th v-if="column && !(!column.visible || local.options.cardView && !column.cardVisible)"
+                            :title="column.titleTooltip"
+                            :class="[{'bs-checkbox': column.checkbox || column.radio}, column.class]"
+                            :style="column.style"
+                            :rowspan="column.rowspan"
+                            :colspan="column.colspan"
+                            :data-field="column.field"
                             tabindex="0">
                             <div class="th-inner"
-                                v-bind:class="[{sortable: options.sortable && column.sortable}, options.sortName == column.field ? options.sortOrder : 'both']"
-                                v-on:click="onSort(column)"
-                                v-on:keypress.enter="onSort(column)">
+                                :class="[{sortable: local.options.sortable && column.sortable},
+                                (local.options.sortable && column.sortable) ? (local.options.sortName == column.field ? local.options.sortOrder : 'both') : '']"
+                                @click="onSort(column)"
+                                @keypress.enter="onSort(column)">
 
-                                <input v-if="column.checkbox && !options.singleSelect && options.checkboxHeader"
+                                <input v-if="column.checkbox && !local.options.singleSelect && local.options.checkboxHeader"
                                     name="btSelectAll" type="checkbox" v-model="selected.all"
-                                    v-on:change="onCheckAllChange">
+                                    @change="onCheckAllChange">
 
                                 <template v-if="!column.checkbox && !column.radio">
                                 {{column.title}}
@@ -131,36 +139,35 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="(i, item) in renderData"
-                        v-bind:class="class"
-                        data-index="{{i}}"
-                        data-uniqueid="{{item[options.uniqueId]}}">
+                    <!-- v-bind:class="class" -->
+                    <tr v-for="(item, i) in renderData"
+                        :data-index="i"
+                        :data-uniqueid="item[local.options.uniqueId]">
 
-                        <template v-if="!options.cardView && options.detailView">
+                        <template v-if="!local.options.cardView && local.options.detailView">
                         <td>
                             <a class="detail-icon" href="javascript:">
-                                <i v-bind:class="[options.iconsPrefix, icons.detailOpen]"></i>
+                                <i :class="[local.options.iconsPrefix, icons.detailOpen]"></i>
                             </a>
                         </td>
                         </template>
 
-                        <template v-if="options.cardView">
-                        <td colspan="{{header.fields.length}}">
+                        <template v-if="local.options.cardView">
+                        <td :colspan="header.fields.length">
                             <div class="card-views">
-                                <div v-for="(j, field) in header.fields" class="card-view"
-                                    v-bind:class="fieldColumns[j].class">
-                                    <template v-if="!(!fieldColumns[j].visible || options.cardView && !fieldColumns[j].cardVisible)">
+                                <div v-for="(field, j) in header.fields" class="card-view"
+                                    :class="fieldColumns[j].class">
+                                    <template v-if="!(!fieldColumns[j].visible || local.options.cardView && !fieldColumns[j].cardVisible)">
                                         <input v-if="fieldColumns[j].checkbox || fieldColumns[j].radio"
-                                            name="{{options.selectItemName}}"
-                                            v-bind:value="item" v-model="selected.items"
-                                            v-on:change="onCheckItemChange(item)"
-                                            v-bind:type="fieldColumns[j].checkbox ? 'checkbox' : 'radio'">
+                                            :name="local.options.selectItemName"
+                                            :value="item" v-model="selected.items"
+                                            @change="onCheckItemChange(item)"
+                                            :type="fieldColumns[j].checkbox ? 'checkbox' : 'radio'">
                                         <div v-else class="card-view">
-                                            <span v-if="options.showHeader" class="title">
+                                            <span v-if="local.options.showHeader" class="title">
                                                 {{fieldColumns[j].title}}
                                             </span>
-                                            <span class="value">
-                                                {{{item | fieldValue field i j}}}
+                                            <span class="value" v-html="fieldValue(item,field, i, j)">
                                             </span>
                                         </div>
                                     </template>
@@ -170,89 +177,94 @@
                         </template>
 
                         <template v-else>
-                            <template v-for="(j, field) in header.fields">
-                                <template v-if="!(!fieldColumns[j].visible || options.cardView && !fieldColumns[j].cardVisible)">
+                            <template v-for="(field, j) in header.fields">
+                                <template v-if="!(!fieldColumns[j].visible || local.options.cardView && !fieldColumns[j].cardVisible)">
                                     <td v-if="fieldColumns[j].checkbox || fieldColumns[j].radio"
-                                        class="bs-checkbox" v-bind:class="fieldColumns[j].class">
-                                        <input name="{{options.selectItemName}}"
-                                        v-bind:value="item" v-model="selected.items"
-                                        v-on:change="onCheckItemChange(item)"
-                                        v-bind:type="fieldColumns[j].checkbox ? 'checkbox' : 'radio'">
+                                        class="bs-checkbox" :class="fieldColumns[j].class">
+                                        <input :name="local.options.selectItemName"
+                                        :value="item" v-model="selected.items"
+                                        @change="onCheckItemChange(item)"
+                                        :type="fieldColumns[j].checkbox ? 'checkbox' : 'radio'">
                                     </td>
                                     <td v-else
-                                        v-on:click="onTdClick(item, fieldColumns[j].field, $event)"
-                                        v-on:dblclick="onTdClick(item, fieldColumns[j].field, $event)">
-                                        {{{item | fieldValue field i j}}}
+                                        @click="onTdClick(item, fieldColumns[j].field, $event)"
+                                        @dblclick="onTdClick(item, fieldColumns[j].field, $event)"
+                                        v-html="fieldValue(item,field, i, j)">
                                     </td>
                                 </template>
                             </template>
                         </template>
                     </tr>
-                    <tr v-if="!renderData.length" class="no-records-found">
-                        <td colspan="{{columnsLength + 1}}">
-                            {{options.formatNoMatches()}}
+                    <tr v-if="!loading && !renderData.length" class="no-records-found">
+                        <td :colspan="columnsLength + 1">
+                            {{local.options.formatNoMatches()}}
                         </td>
                     </tr>
                 </tbody>
             </table>
         </div>
-        <div v-if="options.pagination" class="fixed-table-pagination">
-            <div class="pull-{{options.paginationDetailHAlign}} pagination-detail">
+        <div v-if="local.options.pagination" class="fixed-table-pagination">
+            <div class="pagination-detail"
+            :class="'pull-'+local.options.paginationDetailHAlign">
                 <span class="pagination-info">
-                    <template v-if="options.onlyInfoPagination">
-                    {{options.formatDetailPagination(options.totalRows)}}
+                    <template v-if="local.options.onlyInfoPagination">
+                    {{local.options.formatDetailPagination(local.options.totalRows)}}
                     </template>
                     <template v-else>
-                    {{options.formatShowingRows(pageFrom, pageTo, options.totalRows)}}
+                    {{local.options.formatShowingRows(pageFrom, pageTo, local.options.totalRows)}}
                     </template>
                 </span>
-                <span v-if="!options.onlyInfoPagination" class="page-list">
-                    {{options.formatRecordsPerPage('pageNumber').split('pageNumber')[0]}}
-                    <span class="btn-group {{options.paginationVAlign == 'top' || options.paginationVAlign == 'both' ? 'dropdown' : 'dropup'}}">
-                        <button type="button" class="btn btn-{{options.buttonsClass}} btn-{{options.iconSize}} dropdown-toggle" data-toggle="dropdown">
+                <span v-if="!local.options.onlyInfoPagination" class="page-list">
+                    {{local.options.formatRecordsPerPage('pageNumber').split('pageNumber')[0]}}
+                    <span class="btn-group"
+                    :class="[local.options.paginationVAlign == 'top' || local.options.paginationVAlign == 'both' ? 'dropdown' : 'dropup']">
+                        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown"
+                        :class="['btn-'+local.options.buttonsClass, 'btn-'+local.options.iconSize]">
                             <span class="page-size">
-                                {{options.pageSize === options.totalRows ? options.formatAllRows() : options.pageSize}}
+                                {{local.options.pageSize === local.options.totalRows ? local.options.formatAllRows() : local.options.pageSize}}
                             </span> <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                            <li v-bind:class="{active: page == options.formatAllRows() || page == options.pageSize}"
-                                v-for="page in options.pageList"
-                                v-on:click="onPageListChange">
+                            <li :class="{active: page == local.options.formatAllRows() || page == local.options.pageSize}"
+                                v-for="page in local.options.pageList"
+                                @click="onPageListChange">
                                 <a href="javascript:">{{page}}</a>
                             </li>
                         </ul>
-                    </span> {{options.formatRecordsPerPage('pageNumber').split('pageNumber')[1]}}
+                    </span> {{local.options.formatRecordsPerPage('pageNumber').split('pageNumber')[1]}}
                 </span>
             </div>
-            <div v-if="totalPages > 1" class="pull-{{options.paginationHAlign}} pagination">
-                <ul class="pagination pagination-{{options.iconSize}}">
-                    <li class="page-pre" v-on:click="onPagePre">
-                        <a href="javascript:">{{{options.paginationPreText}}}</a>
+            <div v-if="totalPages > 1" class="pagination"
+                :class="'pull-'+local.options.paginationHAlign">
+                <ul class="pagination"
+                :class="'pagination-'+local.options.iconSize">
+                    <li class="page-pre" @click="onPagePre">
+                        <a href="javascript:" v-html="local.options.paginationPreText"></a>
                     </li>
                     <li v-if="pageInfo.first" class="page-first"
-                        v-bind:class="{active: 1 == options.pageNumber}"
-                        v-on:click="onPageFirst">
+                        :class="{active: 1 == local.options.pageNumber}"
+                        @click="onPageFirst">
                         <a href="javascript:">1</a>
                     </li>
                     <li v-if="pageInfo.firstSeparator" class="page-first-separator disabled">
                         <a href="javascript:">...</a>
                     </li>
                     <li class="page-number"
-                        v-bind:class="{active: i == this.options.pageNumber}"
+                        :class="{active: i == local.options.pageNumber}"
                         v-for="i in pageInfo.list"
-                        v-on:click="onPageNumber">
+                        @click="onPageNumber">
                         <a href="javascript:">{{i}}</a>
                     </li>
                     <li v-if="pageInfo.lastSeparator" class="page-last-separator disabled">
                         <a href="javascript:">...</a>
                     </li>
                     <li v-if="pageInfo.last" class="page-last"
-                        v-bind:class="{active: totalPages == options.pageNumber}"
-                        v-on:click="onPageLast">
+                        :class="{active: totalPages == local.options.pageNumber}"
+                        @click="onPageLast">
                         <a href="javascript:">{{totalPages}}</a>
                     </li>
-                    <li class="page-next" v-on:click="onPageNext">
-                        <a href="javascript:">{{{options.paginationNextText}}}</a>
+                    <li class="page-next" @click="onPageNext">
+                        <a href="javascript:" v-html="local.options.paginationNextText"></a>
                     </li>
                 </ul>
             </div>
@@ -263,14 +275,15 @@
 </template>
 
 <script>
+
 // it only does '%s', and return '' when arguments are undefined
-var sprintf = function (str) {
-    var args = arguments,
+const sprintf = function (str) {
+    let args = arguments,
         flag = true,
         i = 1;
 
     str = str.replace(/%s/g, function () {
-        var arg = args[i++];
+        let arg = args[i++];
 
         if (typeof arg === 'undefined') {
             flag = false;
@@ -282,8 +295,8 @@ var sprintf = function (str) {
 };
 
 // http://jsfiddle.net/wenyi/47nz7ez9/3/
-var setFieldIndex = function (columns) {
-    var i, j, k,
+let setFieldIndex = function (columns) {
+    let i, j, k,
         totalCol = 0,
         flag = [];
 
@@ -300,7 +313,7 @@ var setFieldIndex = function (columns) {
 
     for (i = 0; i < columns.length; i++) {
         for (j = 0; j < columns[i].length; j++) {
-            var r = columns[i][j],
+            let r = columns[i][j],
                 rowspan = r.rowspan || 1,
                 colspan = r.colspan || 1,
                 index = $.inArray(false, flag[i]);
@@ -323,8 +336,8 @@ var setFieldIndex = function (columns) {
     }
 };
 
-var getFieldIndex = function (columns, field) {
-    var index = -1;
+const getFieldIndex = function (columns, field) {
+    let index = -1;
 
     $.each(columns, function (i, column) {
         if (column.field === field) {
@@ -336,12 +349,12 @@ var getFieldIndex = function (columns, field) {
     return index;
 };
 
-var calculateObjectValue = function (self, name, args, defaultValue) {
-    var func = name;
+const calculateObjectValue = function (self, name, args, defaultValue) {
+    let func = name;
 
     if (typeof name === 'string') {
         // support obj.func1.func2
-        var names = name.split('.');
+        let names = name.split('.');
 
         if (names.length > 1) {
             func = window;
@@ -364,7 +377,7 @@ var calculateObjectValue = function (self, name, args, defaultValue) {
     return defaultValue;
 };
 
-var escapeHTML = function (text) {
+const escapeHTML = function (text) {
     if (typeof text === 'string') {
         return text
             .replace(/&/g, '&amp;')
@@ -377,24 +390,24 @@ var escapeHTML = function (text) {
     return text;
 };
 
-var getItemField = function (item, field, escape, undefinedText) {
-    var value = item;
+const getItemField = function (item, field, escape, undefinedText) {
+    let value = item;
 
     if (typeof field !== 'string' || item.hasOwnProperty(field)) {
         return escape ? escapeHTML(item[field]) : item[field];
     }
-    var props = field.split('.');
-    for (var p in props) {
+    let props = field.split('.');
+    for (let p in props) {
         value = value && value[props[p]];
     }
     return (escape ? escapeHTML(value) : value) || undefinedText;
 };
 
-var checkAllIndexOf = function (type, items, data, from, to) {
+const checkAllIndexOf = function (type, items, data, from, to) {
     if (type === 'radio') {
         return false;
     }
-    for (var i = from; i < to; i++) {
+    for (let i = from; i < to; i++) {
         if (items.indexOf(data[i]) === -1) {
             return false;
         }
@@ -402,7 +415,7 @@ var checkAllIndexOf = function (type, items, data, from, to) {
     return true;
 };
 
-var DEFAULTS = {
+let DEFAULTS = {
     classes: 'table table-hover',
     height: undefined,
     undefinedText: '-',
@@ -443,9 +456,9 @@ var DEFAULTS = {
     pageList: [10, 25, 50, 100],
     paginationPreText: '&lsaquo;',
     paginationNextText: '&rsaquo;',
-    paginationHAlign: 'right', //right, left
-    paginationVAlign: 'bottom', //bottom, top, both
-    paginationDetailHAlign: 'left', //right, left
+    paginationHAlign: 'right', // right, left
+    paginationVAlign: 'bottom', // bottom, top, both
+    paginationDetailHAlign: 'left', // right, left
 
     search: false,
     searchText: '',
@@ -495,9 +508,11 @@ var DEFAULTS = {
     footerStyle: function (row, index) {
         return {};
     },
+
+    checkbox: true,
 };
 
-var COLUMN_DEFAULTS = {
+let COLUMN_DEFAULTS = {
     field: undefined,
     title: undefined,
     titleTooltip: undefined,
@@ -564,26 +579,38 @@ LOCALES['en-US'] = LOCALES.en = {
 
 $.extend(DEFAULTS, LOCALES['en-US']);
 
-var BootstrapTable = {
+let BootstrapTable =
+{
+    name: 'BootstrapTable',
     props: {
-        columns: {
+        my_columns: {
             type: Array,
             required: true,
             default: function () { return []; }
         },
-        data: {
+        my_data: {
             type: Array,
             default: function () { return []; }
         },
-        options: {
+        my_options: {
             type: Object,
             default: function () { return DEFAULTS; }
         }
     },
-    data: function () {
+    data () {
         return {
             fieldColumns: {},
-            header: {},
+            header: {
+                fields: [],
+                styles: [],
+                classes: [],
+                formatters: [],
+                events: [],
+                sorters: [],
+                sortNames: [],
+                cellStyles: [],
+                searchables: []
+            },
             pageFrom: 1,
             pageTo: 1,
             totalPages: 0,
@@ -596,10 +623,46 @@ var BootstrapTable = {
             },
             view: {
                 headerHeight: 0
-            }
+            },
+
+            local:{
+                columns:[],
+                data :[],
+                options:{},
+            },
+
+            _renderData:[],
         };
     },
+    watch: {
+        my_columns (val) {
+            let vm = this;
+
+            if(vm.my_columns){
+                vm.$set(vm.local,'columns',vm.my_columns.slice());
+            }
+
+            vm.initTable();
+            vm.initHeader();
+
+            if(this._renderData){
+                this.$nextTick(this.resetView);
+            }
+        },
+    },
     created: function () {
+        let vm = this;
+
+        vm.$set(vm.local,'options',$.extend({}, DEFAULTS, vm.my_options));
+
+        if(vm.my_columns){
+            vm.$set(vm.local,'columns',vm.my_columns.slice());
+        }
+
+        if(vm.my_data){
+            vm.$set(vm.local,'data',vm.my_data);
+        }
+
         this.initLocale();
         this.initTable();
         this.initHeader();
@@ -609,14 +672,14 @@ var BootstrapTable = {
     },
     computed: {
         paginationSwitchIcon: function () {
-            return this.options.icons[this.options.pagination ?
-                'paginationSwitchDown' : 'paginationSwitchUp'];
+            return this.local.options.icons[this.local.options.pagination
+                ? 'paginationSwitchDown' : 'paginationSwitchUp'];
         },
         toggleColumnsCount: function () {
-            var count = 0;
-            for (var i in this.fieldColumns) {
+            let count = 0;
+            for (let i in this.fieldColumns) {
                 if (!(this.fieldColumns[i].radio || this.fieldColumns[i].checkbox ||
-                        this.options.cardView && !this.fieldColumns[i].cardVisible) &&
+                        this.local.options.cardView && !this.fieldColumns[i].cardVisible) &&
                         this.fieldColumns[i].visible) {
                     count++;
                 }
@@ -624,15 +687,15 @@ var BootstrapTable = {
             return count;
         },
         renderData: function () {
-            var that = this,
-                data = this.data.slice(this.pageFrom - 1, this.pageTo);
+            let that = this,
+                data = this.local.data.slice(this.pageFrom - 1, this.pageTo);
 
             data.forEach(function (item, i) {
-                var key,
+                let key,
                     style = {},
                     csses = [];
 
-                style = calculateObjectValue(that.options, that.options.rowStyle, [item, i], style);
+                style = calculateObjectValue(that.local.options, that.local.options.rowStyle, [item, i], style);
 
                 if (style && style.css) {
                     for (key in style.css) {
@@ -643,22 +706,22 @@ var BootstrapTable = {
                 item.csses = csses;
             });
 
-            if (!this.options.maintainSelected) {
+            if (!this.local.options.maintainSelected) {
                 this.selected.all = false;
                 this.selected.items = [];
             } else {
                 this.selected.all = checkAllIndexOf(this.selected.type,
-                    this.selected.items, this.data, this.pageFrom - 1, this.pageTo);
+                    this.selected.items, this.local.data, this.pageFrom - 1, this.pageTo);
             }
 
-            if (this.options.sidePagination !== 'server') {
-                var s = this.searchText && (this.options.escape ?
-                    escapeHTML(this.searchText) : this.searchText).toLowerCase();
+            if (this.local.options.sidePagination !== 'server') {
+                let s = this.searchText && (this.local.options.escape
+                    ? escapeHTML(this.searchText) : this.searchText).toLowerCase();
 
                 data = s ? $.grep(data, function (item, i) {
-                    for (var key in item) {
+                    for (let key in item) {
                         key = $.isNumeric(key) ? parseInt(key, 10) : key;
-                        var value = item[key],
+                        let value = item[key],
                             column = that.fieldColumns[getFieldIndex(that.fieldColumns, key)],
                             j = $.inArray(key, that.header.fields);
 
@@ -668,9 +731,9 @@ var BootstrapTable = {
                                 that.header.formatters[j], [value, item, i], value);
                         }
 
-                        var index = $.inArray(key, that.header.fields);
+                        let index = $.inArray(key, that.header.fields);
                         if (index !== -1 && that.header.searchables[index] && (typeof value === 'string' || typeof value === 'number')) {
-                            if (that.options.strictSearch) {
+                            if (that.local.options.strictSearch) {
                                 if ((value + '').toLowerCase() === s) {
                                     return true;
                                 }
@@ -690,14 +753,14 @@ var BootstrapTable = {
             return data;
         },
         pageInfo: function () {
-            var i, from, to,
+            let i, from, to,
                 info = {};
 
             if (this.totalPages < 5) {
                 from = 1;
                 to = this.totalPages;
             } else {
-                from = this.options.pageNumber - 2;
+                from = this.local.options.pageNumber - 2;
                 to = from + 4;
                 if (from < 1) {
                     from = 1;
@@ -710,13 +773,13 @@ var BootstrapTable = {
             }
 
             if (this.totalPages >= 6) {
-                if (this.options.pageNumber >= 3) {
+                if (this.local.options.pageNumber >= 3) {
                     info.first = true;
                     from++;
                 }
 
-                if (this.options.pageNumber >= 4) {
-                    if (this.options.pageNumber == 4 || this.totalPages == 6 || this.totalPages == 7) {
+                if (this.local.options.pageNumber >= 4) {
+                    if (this.local.options.pageNumber == 4 || this.totalPages == 6 || this.totalPages == 7) {
                         from--;
                     } else {
                         info.firstSeparator = true;
@@ -726,14 +789,14 @@ var BootstrapTable = {
                 }
             }
 
-            if (this.totalPages >= 7 && this.options.pageNumber >= (this.totalPages - 2)) {
+            if (this.totalPages >= 7 && this.local.options.pageNumber >= (this.totalPages - 2)) {
                 from--;
             }
 
-            if (this.totalPages === 6 && this.options.pageNumber >= this.totalPages - 2) {
+            if (this.totalPages === 6 && this.local.options.pageNumber >= this.totalPages - 2) {
                 to++;
             } else if (this.totalPages >= 7 && (this.totalPages === 7 ||
-                    this.options.pageNumber >= this.totalPages - 3)) {
+                    this.local.options.pageNumber >= this.totalPages - 3)) {
                 to++;
             }
 
@@ -742,11 +805,11 @@ var BootstrapTable = {
                 info.list.push(i);
             }
 
-            if (this.totalPages >= 8 && this.options.pageNumber <= this.totalPages - 4) {
+            if (this.totalPages >= 8 && this.local.options.pageNumber <= this.totalPages - 4) {
                 info.lastSeparator = true;
             }
 
-            if (this.totalPages >= 6 && this.options.pageNumber <= this.totalPages - 3) {
+            if (this.totalPages >= 6 && this.local.options.pageNumber <= this.totalPages - 3) {
                 info.last = true;
             }
             return info;
@@ -757,72 +820,65 @@ var BootstrapTable = {
     },
     methods: {
         initLocale: function () {
-            if (!this.options.locale) {
+            if (!this.local.options.locale) {
                 return;
             }
-            var parts = this.options.locale.split(/-|_/);
+            let parts = this.local.options.locale.split(/-|_/);
             parts[0].toLowerCase();
             if (parts[1]) parts[1].toUpperCase();
-            if (BootstrapTable.locales[this.options.locale]) {
+            if (BootstrapTable.locales[this.local.options.locale]) {
                 // locale as requested
-                $.extend(this.options, BootstrapTable.locales[this.options.locale]);
+                this.$set(this.local,'options',
+                    $.extend(this.local.options, BootstrapTable.locales[this.local.options.locale]));
             } else if (BootstrapTable.locales[parts.join('-')]) {
                 // locale with sep set to - (in case original was specified with _)
-                $.extend(this.options, BootstrapTable.locales[parts.join('-')]);
+                this.$set(this.local,'options',
+                    $.extend(this.local.options, BootstrapTable.locales[parts.join('-')]));
             } else if (BootstrapTable.locales[parts[0]]) {
                 // short locale language code (i.e. 'en')
-                $.extend(this.options, BootstrapTable.locales[parts[0]]);
+                this.$set(this.local,'options',
+                    $.extend(this.local.options, BootstrapTable.locales[parts[0]]));
             }
         },
         initTable: function () {
-            var that = this,
+            let that = this,
                 columns = {};
 
-            this.options = $.extend({}, DEFAULTS, this.options);
-            if (!Array.isArray(this.columns[0])) {
-                this.columns = [this.columns];
+            if (!Array.isArray(this.local.columns[0])) {
+                this.$set(this.local,'columns',[this.local.columns]);
             }
-            setFieldIndex(this.columns);
-            this.columns.forEach(function (_columns, i) {
+            setFieldIndex(this.local.columns);
+            this.local.columns.forEach(function (_columns, i) {
                 _columns.forEach(function (column, j) {
                     column = $.extend({}, COLUMN_DEFAULTS, column);
 
                     if (typeof column.fieldIndex !== 'undefined') {
+
                         columns[column.fieldIndex] = column;
                     }
-
-                    that.columns[i][j] = column;
+                    that.$set(that.local.columns[i],j,column);
                 });
             });
-            this.fieldColumns = columns;
-            this.searchText = this.options.searchText;
+            for(let k in columns){
+                this.$set(this.fieldColumns,k,columns[k]);
+            }
+            this.searchText = this.local.options.searchText;
             this.timeoutId = 0;
         },
         initHeader: function () {
-            var that = this,
+            let that = this,
                 visibleColumns = {};
 
-            this.header = {
-                fields: [],
-                styles: [],
-                classes: [],
-                formatters: [],
-                events: [],
-                sorters: [],
-                sortNames: [],
-                cellStyles: [],
-                searchables: []
-            };
-            this.columns.forEach(function (columns, i) {
+            this.local.columns.forEach(function (columns, i) {
                 columns.forEach(function (column, j) {
-                    var halign = '', // header align style
+                    let halign = '', // header align style
                         align = '', // body align style
                         style = '',
                         class_ = sprintf(' class="%s"', column['class']),
                         unitWidth = 'px',
                         width = column.width;
 
-                    if (column.width !== undefined && (!that.options.cardView)) {
+                    if (column.width !== undefined && (!that.local.options.cardView)) {
                         if (typeof column.width === 'string') {
                             if (column.width.indexOf('%') !== -1) {
                                 unitWidth = '%';
@@ -836,8 +892,8 @@ var BootstrapTable = {
                     halign = sprintf('text-align: %s; ', column.halign ? column.halign : column.align);
                     align = sprintf('text-align: %s; ', column.align);
                     style = sprintf('vertical-align: %s; ', column.valign);
-                    style += sprintf('width: %s; ', (column.checkbox || column.radio) && !width ?
-                        '36px' : (width ? width + unitWidth : undefined));
+                    style += sprintf('width: %s; ', (column.checkbox || column.radio) && !width
+                        ? '36px' : (width ? width + unitWidth : undefined));
 
                     column.style = halign + style;
 
@@ -856,7 +912,7 @@ var BootstrapTable = {
                             return;
                         }
 
-                        if (that.options.cardView && (!column.cardVisible)) {
+                        if (that.local.options.cardView && (!column.cardVisible)) {
                             return;
                         }
 
@@ -871,18 +927,18 @@ var BootstrapTable = {
             });
         },
         onSort: function (column) {
-            if (!this.options.sortable || !column.sortable) {
+            if (!this.local.options.sortable || !column.sortable) {
                 return;
             }
-            if (this.options.sortName === column.field) {
-                this.options.sortOrder = this.options.sortOrder === 'asc' ? 'desc' : 'asc';
+            if (this.local.options.sortName === column.field) {
+                this.local.options.sortOrder = this.local.options.sortOrder === 'asc' ? 'desc' : 'asc';
             } else {
-                this.options.sortName = column.field;
-                this.options.sortOrder = column.order === 'asc' ? 'desc' : 'asc';
+                this.local.options.sortName = column.field;
+                this.local.options.sortOrder = column.order === 'asc' ? 'desc' : 'asc';
             }
-            this.trigger('sort', this.options.sortName, this.options.sortOrder);
+            this.trigger('sort', this.local.options.sortName, this.local.options.sortOrder);
 
-            if (this.options.sidePagination === 'server') {
+            if (this.local.options.sidePagination === 'server') {
                 this.initServer();
                 return;
             }
@@ -891,24 +947,24 @@ var BootstrapTable = {
             this.initBody();
         },
         initSort: function () {
-            var that = this,
-                name = this.options.sortName,
-                order = this.options.sortOrder === 'desc' ? -1 : 1,
-                index = this.header.fields.indexOf(this.options.sortName);
+            let that = this,
+                name = this.local.options.sortName,
+                order = this.local.options.sortOrder === 'desc' ? -1 : 1,
+                index = this.header.fields.indexOf(this.local.options.sortName);
 
             if (index !== -1) {
-                if (this.options.sortStable) {
-                    this.data.forEach(function (row, i) {
+                if (this.local.options.sortStable) {
+                    this.local.data.forEach(function (row, i) {
                         if (!row.hasOwnProperty('_position')) row._position = i;
                     });
                 }
 
-                this.data.sort(function (a, b) {
+                this.local.data.sort(function (a, b) {
                     if (that.header.sortNames[index]) {
                         name = that.header.sortNames[index];
                     }
-                    var aa = getItemField(a, name, that.options.escape),
-                        bb = getItemField(b, name, that.options.escape),
+                    let aa = getItemField(a, name, that.local.options.escape),
+                        bb = getItemField(b, name, that.local.options.escape),
                         value = calculateObjectValue(that.header, that.header.sorters[index], [aa, bb]);
 
                     if (value !== undefined) {
@@ -923,7 +979,7 @@ var BootstrapTable = {
                         bb = '';
                     }
 
-                    if (that.options.sortStable && aa === bb) {
+                    if (that.local.options.sortStable && aa === bb) {
                         aa = a._position;
                         bb = b._position;
                     }
@@ -957,8 +1013,8 @@ var BootstrapTable = {
             }
         },
         search: function (event) {
-            var that = this;
-            if (this.options.searchOnEnterKey && event.keyCode !== 13) {
+            let that = this;
+            if (this.local.options.searchOnEnterKey && event.keyCode !== 13) {
                 return;
             }
 
@@ -969,29 +1025,29 @@ var BootstrapTable = {
             clearTimeout(this.timeoutId); // doesn't matter if it's 0
             this.timeoutId = setTimeout(function () {
                 that.onSearch(event);
-            }, this.options.searchTimeOut);
+            }, this.local.options.searchTimeOut);
         },
         onSearch: function (event) {
-            if (this.options.trimOnSearch) {
+            if (this.local.options.trimOnSearch) {
                 this.searchText = this.searchText.trim();
             }
 
-            if (this.options.searchText === this.searchText) {
+            if (this.local.options.searchText === this.searchText) {
                 return;
             }
-            this.options.searchText = this.searchText;
+            this.local.options.searchText = this.searchText;
 
-            this.options.pageNumber = 1;
+            this.local.options.pageNumber = 1;
             this.updatePagination();
             this.trigger('search', this.searchText);
         },
         togglePagination: function () {
-            this.options.pagination = !this.options.pagination;
+            this.local.options.pagination = !this.local.options.pagination;
             this.updatePagination();
         },
         refresh: function (params) {
             if (params && params.url) {
-                this.options.pageNumber = 1;
+                this.local.options.pageNumber = 1;
             }
             this.initServer(params && params.silent,
                 params && params.query, params && params.url);
@@ -999,94 +1055,94 @@ var BootstrapTable = {
             this.trigger('refresh', params);
         },
         toggleView: function () {
-            this.options.cardView = !this.options.cardView;
+            this.local.options.cardView = !this.local.options.cardView;
             this.initBody();
-            this.trigger('toggle', this.options.cardView);
+            this.trigger('toggle', this.local.options.cardView);
         },
         initPagination: function () {
-            if (this.options.sidePagination !== 'server') {
-                this.options.totalRows = this.data.length;
+            if (this.local.options.sidePagination !== 'server') {
+                this.local.options.totalRows = this.local.data.length;
             }
 
             this.totalPages = 0;
-            if (this.options.totalRows) {
-                if (this.options.pageSize === this.options.formatAllRows()) {
-                    this.options.pageSize = this.options.totalRows;
+            if (this.local.options.totalRows) {
+                if (this.local.options.pageSize === this.local.options.formatAllRows()) {
+                    this.local.options.pageSize = this.local.options.totalRows;
                 }
 
-                this.totalPages = ~~((this.options.totalRows - 1) / this.options.pageSize) + 1;
+                this.totalPages = ~~((this.local.options.totalRows - 1) / this.local.options.pageSize) + 1;
 
-                this.options.totalPages = this.totalPages;
+                this.local.options.totalPages = this.totalPages;
             }
-            if (this.totalPages > 0 && this.options.pageNumber > this.totalPages) {
-                this.options.pageNumber = this.totalPages;
+            if (this.totalPages > 0 && this.local.options.pageNumber > this.totalPages) {
+                this.local.options.pageNumber = this.totalPages;
             }
 
-            this.pageFrom = (this.options.pageNumber - 1) * this.options.pageSize + 1;
-            this.pageTo = this.options.pageNumber * this.options.pageSize;
-            if (this.pageTo > this.options.totalRows) {
-                this.pageTo = this.options.totalRows;
+            this.pageFrom = (this.local.options.pageNumber - 1) * this.local.options.pageSize + 1;
+            this.pageTo = this.local.options.pageNumber * this.local.options.pageSize;
+            if (this.pageTo > this.local.options.totalRows) {
+                this.pageTo = this.local.options.totalRows;
             }
         },
         updatePagination: function () {
             this.initPagination();
-            if (this.options.sidePagination === 'server') {
+            if (this.local.options.sidePagination === 'server') {
                 this.initServer();
             } else {
                 this.initBody();
             }
         },
         onPageListChange: function (event) {
-            var $this = $(event.currentTarget);
+            let $this = $(event.currentTarget);
 
-            this.options.pageSize = $this.text().toUpperCase() === this.options.formatAllRows().toUpperCase() ?
-                this.options.formatAllRows() : +$this.text();
+            this.local.options.pageSize = $this.text().toUpperCase() === this.local.options.formatAllRows().toUpperCase()
+                ? this.local.options.formatAllRows() : +$this.text();
 
             this.updatePagination();
         },
         onPagePre: function () {
-            if (this.options.pageNumber - 1 === 0) {
-                this.options.pageNumber = this.options.totalPages;
+            if (this.local.options.pageNumber - 1 === 0) {
+                this.local.options.pageNumber = this.local.options.totalPages;
             } else {
-                this.options.pageNumber--;
+                this.local.options.pageNumber--;
             }
             this.updatePagination();
         },
         onPageFirst: function () {
-            this.options.pageNumber = 1;
+            this.local.options.pageNumber = 1;
             this.updatePagination();
         },
         onPageNumber: function (event) {
-            var number = +$(event.currentTarget).text();
-            if (this.options.pageNumber === number) {
+            let number = +$(event.currentTarget).text();
+            if (this.local.options.pageNumber === number) {
                 return;
             }
-            this.options.pageNumber = number;
+            this.local.options.pageNumber = number;
             this.updatePagination();
         },
         onPageLast: function () {
-            this.options.pageNumber = this.totalPages;
+            this.local.options.pageNumber = this.totalPages;
             this.updatePagination();
         },
         onPageNext: function () {
-            if ((this.options.pageNumber + 1) > this.options.totalPages) {
-                this.options.pageNumber = 1;
+            if ((this.local.options.pageNumber + 1) > this.local.options.totalPages) {
+                this.local.options.pageNumber = 1;
             } else {
-                this.options.pageNumber++;
+                this.local.options.pageNumber++;
             }
             this.updatePagination();
         },
         initBody: function (fixedScroll) {
-            if (!this.options.pagination || this.options.sidePagination === 'server') {
+            if (!this.local.options.pagination || this.local.options.sidePagination === 'server') {
                 this.pageFrom = 1;
-                this.pageTo = this.data.length;
+                this.pageTo = this.local.data.length;
             }
         },
         onCheckAllChange: function () {
-            var items = [];
+            let items = [];
             if (this.selected.all) {
-                for (var i = this.pageFrom - 1; i < this.pageTo; i++) {
-                    items.push(this.data[i]);
+                for (let i = this.pageFrom - 1; i < this.pageTo; i++) {
+                    items.push(this.local.data[i]);
                 }
             }
             this.selected.items = items;
@@ -1094,31 +1150,31 @@ var BootstrapTable = {
         },
         onCheckItemChange: function (item) {
             this.selected.all = checkAllIndexOf(this.selected.type,
-                this.selected.items, this.data, this.pageFrom - 1, this.pageTo);
+                this.selected.items, this.local.data, this.pageFrom - 1, this.pageTo);
 
             if (this.selected.type === 'radio') {
                 this.trigger('check', item);
             } else {
-                var selected = this.selected.items.indexOf(item) > - 1;
-                if (this.options.singleSelect) {
+                let selected = this.selected.items.indexOf(item) > -1;
+                if (this.local.options.singleSelect) {
                     this.selected.items = selected ? [item] : [];
                 }
                 this.trigger(selected ? 'check' : 'uncheck', item);
             }
         },
         onTdClick: function (item, field, e) {
-            var column = this.fieldColumns[getFieldIndex(this.fieldColumns, field)],
-                value = getItemField(item, field, this.options.escape);
+            let column = this.fieldColumns[getFieldIndex(this.fieldColumns, field)],
+                value = getItemField(item, field, this.local.options.escape);
 
             this.trigger(e.type === 'click' ? 'click-cell' : 'dbl-click-cell', field, value, item);
             this.trigger(e.type === 'click' ? 'click-row' : 'dbl-click-row', item, field);
 
             // if click to select - then trigger the checkbox/radio click
-            if (e.type === 'click' && this.options.clickToSelect && column.clickToSelect) {
+            if (e.type === 'click' && this.local.options.clickToSelect && column.clickToSelect) {
                 if (this.selected.type === 'radio') {
                     this.selected.items = item;
                 } else {
-                    var index = this.selected.items.indexOf(item);
+                    let index = this.selected.items.indexOf(item);
                     if (index > -1) {
                         this.selected.items.splice(index, 1);
                     } else {
@@ -1129,37 +1185,36 @@ var BootstrapTable = {
             }
         },
         initServer: function (silent, query, url) {
-            var that = this,
+            let that = this,
                 data = {},
                 params = {
                     searchText: this.searchText,
-                    sortName: this.options.sortName,
-                    sortOrder: this.options.sortOrder
+                    sortName: this.local.options.sortName,
+                    sortOrder: this.local.options.sortOrder
                 },
                 request;
 
-            if (this.options.pagination) {
-                params.pageSize = this.options.pageSize === this.options.formatAllRows() ?
-                    this.options.totalRows : this.options.pageSize;
-                params.pageNumber = this.options.pageNumber;
+            if (this.local.options.pagination) {
+                params.pageSize = this.local.options.pageSize === this.local.options.formatAllRows()
+                    ? this.local.options.totalRows : this.local.options.pageSize;
+                params.pageNumber = this.local.options.pageNumber;
             }
 
-            if (!(url || this.options.url) && !this.options.ajax) {
+            if (!(url || this.local.options.url) && !this.local.options.ajax) {
                 return;
             }
-
-            if (this.options.queryParamsType === 'limit') {
+            if (this.local.options.queryParamsType === 'limit') {
                 params = {
                     search: params.searchText,
                     sort: params.sortName,
                     order: params.sortOrder
                 };
 
-                if (this.options.pagination) {
-                    params.offset = this.options.pageSize === this.options.formatAllRows() ?
-                        0 : this.options.pageSize * (this.options.pageNumber - 1);
-                    params.limit = this.options.pageSize === this.options.formatAllRows() ?
-                        this.options.totalRows : this.options.pageSize;
+                if (this.local.options.pagination) {
+                    params.offset = this.local.options.pageSize === this.local.options.formatAllRows()
+                        ? 0 : this.local.options.pageSize * (this.local.options.pageNumber - 1);
+                    params.limit = this.local.options.pageSize === this.local.options.formatAllRows()
+                        ? this.local.options.totalRows : this.local.options.pageSize;
                 }
             }
 
@@ -1167,7 +1222,7 @@ var BootstrapTable = {
                 params.filter = JSON.stringify(this.filterColumnsPartial, null);
             }
 
-            data = calculateObjectValue(this.options, this.options.queryParams, [params], data);
+            data = calculateObjectValue(this.local.options, this.local.options.queryParams, [params], data);
 
             $.extend(data, query || {});
 
@@ -1179,16 +1234,16 @@ var BootstrapTable = {
             if (!silent) {
                 this.loading = true;
             }
-            request = $.extend({}, calculateObjectValue(null, this.options.ajaxOptions), {
-                type: this.options.method,
-                url:  url || this.options.url,
-                data: this.options.contentType === 'application/json' && this.options.method === 'post' ?
-                    JSON.stringify(data) : data,
-                cache: this.options.cache,
-                contentType: this.options.contentType,
-                dataType: this.dataType,
+            request = $.extend({}, calculateObjectValue(null, this.local.options.ajaxoptions), {
+                type: this.local.options.method,
+                url: url || this.local.options.url,
+                data: this.local.options.contentType === 'application/json' && this.local.options.method === 'post'
+                    ? JSON.stringify(data) : data,
+                cache: this.local.options.cache,
+                contentType: this.local.options.contentType,
+                dataType: this.local.options.dataType,
                 success: function (res) {
-                    res = calculateObjectValue(that.options, that.options.responseHandler, [res], res);
+                    res = calculateObjectValue(that.local.options, that.local.options.responseHandler, [res], res);
 
                     that.load(res);
                     if (!silent) that.loading = false;
@@ -1200,8 +1255,8 @@ var BootstrapTable = {
                 }
             });
 
-            if (this.options.ajax) {
-                calculateObjectValue(this, this.options.ajax, [request], null);
+            if (this.local.options.ajax) {
+                calculateObjectValue(this, this.local.options.ajax, [request], null);
             } else {
                 if (this._xhr && this._xhr.readyState !== 4) {
                     this._xhr.abort();
@@ -1210,28 +1265,29 @@ var BootstrapTable = {
             }
         },
         load: function (data) {
-            var fixedScroll = false;
+            let fixedScroll = false;
 
-            if (this.options.sidePagination === 'server') {
-                this.options.totalRows = data[this.options.responseTotalField];
+            if (this.local.options.sidePagination === 'server') {
+                this.local.options.totalRows = data[this.local.options.responseTotalField];
                 fixedScroll = data.fixedScroll;
-                data = data[this.options.responseRowsField];
+                data = data[this.local.options.responseRowsField];
             } else if (!$.isArray(data)) { // support fixedScroll
                 fixedScroll = data.fixedScroll;
                 data = data.data;
             }
-            this.data = data;
+            // this.local.data = data;
+            this.$set(this.local,'data',data);
 
             this.initSort();
             this.initPagination();
             this.initBody(fixedScroll);
         },
         getVisibleFields: function () {
-            var that = this,
+            let that = this,
                 visibleFields = [];
 
             this.header.fields.forEach(function (field) {
-                var column = that.fieldColumns[getFieldIndex(that.fieldColumns, field)];
+                let column = that.fieldColumns[getFieldIndex(that.fieldColumns, field)];
 
                 if (!column.visible) {
                     return;
@@ -1241,38 +1297,45 @@ var BootstrapTable = {
             return visibleFields;
         },
         resetView: function () {
-            var that = this,
+            let that = this,
                 $el = $(this.$el);
 
             this.view.headerHeight = $el.find('thead:visible').height();
+        // Sometimes header not loaded
+            if(that.view.headerHeight === 0 && that.local.options.showHeader
+                && !that.local.options.cardView
+                ) {
+                that.view.headerHeight = 40;
+            }
 
             this.header.events.forEach(function (events, i) {
                 if (!events) {
                     return;
                 }
+
                 // if events is defined with namespace
                 if (typeof events === 'string') {
                     events = calculateObjectValue(null, events);
                 }
 
-                var field = that.header.fields[i],
+                let field = that.header.fields[i],
                     fieldIndex = that.getVisibleFields().indexOf(field);
 
-                if (that.options.detailView && !that.options.cardView) {
+                if (that.local.options.detailView && !that.local.options.cardView) {
                     fieldIndex += 1;
                 }
 
-                for (var key in events) {
+                for (let key in events) {
                     $el.find('tbody >tr:not(.no-records-found)').each(function () {
-                        var $tr = $(this),
-                            $td = $tr.find(that.options.cardView ? '.card-view' : 'td').eq(fieldIndex),
+                        let $tr = $(this),
+                            $td = $tr.find(that.local.options.cardView ? '.card-view' : 'td').eq(fieldIndex),
                             index = key.indexOf(' '),
                             name = key.substring(0, index),
                             el = key.substring(index + 1),
                             func = events[key];
 
                         $td.find(el).off(name).on(name, function (e) {
-                            var index = $tr.data('index'),
+                            let index = $tr.data('index'),
                                 row = that._renderData[index],
                                 value = row[field];
 
@@ -1282,30 +1345,69 @@ var BootstrapTable = {
                 }
             });
         },
-        trigger: function (name) {
-            var args = Array.prototype.slice.call(arguments, 1);
+        trigger: function (name,...args) {
+            // let args = Array.prototype.slice.call(arguments, 1);
 
-            name += '.bs.table';
+        // Deconstructing the remaining parameters for convenience
+            this.$emit(name,...args);
             console.log(name, args);
-        }
-    },
-    filters: {
+
+        // Does not seem to support
+            // name += '.bs.table';
+        },
+    // vue2 v-html does not work with filters
         fieldValue: function (item, field, i, j) {
-            var value = getItemField(item, field, this.options.escape),
+            let value = getItemField(item, field, this.local.options.escape),
                 column = this.fieldColumns[j];
 
             return calculateObjectValue(column,
                 this.header.formatters[j], [value, item, i], value);
+        },
+        getSelections(){
+            let vm = this;
+            return vm.selected.items;
+        },
+        getOptions(){
+            let vm = this;
+            return vm.local.options;
+        },
+        updateRow(index,row){
+            let vm = this;
+            let id = vm.local.options.uniqueId;
+
+            if(vm.local.data && row && row[id]){
+                for(let index in vm.local.data){
+                    if (vm.local.data[index][id] === row[id]){
+                        vm.$set(vm.local.data,index,row);
+                        break;
+                    }
+                }
+            }
+
+            // if(vm.local.data && vm.local.data.length > index && row){
+            //     vm.$set(vm.local.data,index,row);
+            // }
         }
-    }
+    },
+    // filters: {
+    //     fieldValue: function (item, field, i, j) {
+    //         let value = getItemField(item, field, this.local.options.escape),
+    //             column = this.fieldColumns[j];
+
+    //         return calculateObjectValue(column,
+    //             this.header.formatters[j], [value, item, i], value);
+    //     }
+    // },
 };
 
 BootstrapTable.defaults = DEFAULTS;
 BootstrapTable.column_defaults = COLUMN_DEFAULTS;
 BootstrapTable.locales = LOCALES;
 
-module.exports = BootstrapTable;
+export default BootstrapTable;
+
 </script>
+
 
 <style>
 .bootstrap-table .table {


### PR DESCRIPTION
作者您好！非常感谢bootstrap-table的开源和更新！
之前一直使用bootstrap-table，后来项目升级到vue框架了，不想做大的改动，看到有vue1版本，就尝试着修改一下试试，因水平和时间原因尚不太完善，求多多指点！

修改内容：

1. props属性重命名，添加对应local变量
2. 修改多处赋值操作，改用vue.$set方法赋值，以使vue自动追踪值变更
3. 添加columns的watch，当列变更时重新加载
4. vue2不支持v-html和filters组合，修改为method
5. v-for的参数在vue1和vue2顺序不同，修改
6. 修改trigger(.bs.table好像不支持，所以去掉了)，解构回调参数，方便参数处理
7. 添加方法getSelections，getOptions，updateRow，在父组件可添加ref调用

遗留问题：
1. 下面使用的class没有找到，所以暂时注释掉了。
```html
<tbody>
                    <tr v-for="(i, item) in renderData"
                        v-bind:class="class"
                        data-index="{{i}}"
                        data-uniqueid="{{item[options.uniqueId]}}">
```
2. options变更watch暂未添加(配置可能动态修改)


